### PR TITLE
fix wrong highlight of 'rem'-containing string

### DIFF
--- a/grammars/batch.cson
+++ b/grammars/batch.cson
@@ -8,7 +8,7 @@
 'patterns': [
   # single line comments
   {
-    'match': '(REM|rem).*$|::.*$'
+    'match': '(REM |rem ).*$|::.*$'
     'name': 'comment.line.batch'
   }
   # label declaration


### PR DESCRIPTION
if string contain 'rem', it highlighted as comment (i.e. in 'netsh advfirewall... remoteip=10.43.1.1' - 'remote=10.43.1.1' highlighted as comment