### PR TITLE
fancier comment matching

### DIFF
--- a/grammars/batch.cson
+++ b/grammars/batch.cson
@@ -6,9 +6,14 @@
 ]
 'name': 'Batch'
 'patterns': [
-  # single line comments
+  # single line comments using REM
   {
-    'match': '(REM |rem ).*$|::.*$'
+    'match': '(^|&)\\s*@?\\s*((?i)rem)($|\\s.*$)'
+    'name': 'comment.line.batch'
+  }
+  # single line comments using ::
+  {
+    'match': '(^|&)\\s*@?\\s*::.*$'
     'name': 'comment.line.batch'
   }
   # label declaration


### PR DESCRIPTION
Detects comments more reliably (the regex is similar to mmims/language-batchfile but enhanced).

Considering the following test file:
```
@echo off
@rem intro comment
 @ rem
::previous line was a comment!

echo not a comment: rem false
echo not a comment: :: neither
echo nope& rem this is a comment
echo nope &rem this one too
echo nope &::comment!
```

The output is:
![image](https://cloud.githubusercontent.com/assets/1114120/25772134/f64c49ea-3263-11e7-83fd-dc9402895698.png)

Which corresponds to how cmd parses the file.

Compared to current parsing:
![image](https://cloud.githubusercontent.com/assets/1114120/25772147/7cc72fbc-3264-11e7-8b68-c4bd9b923bf9.png)




